### PR TITLE
ft(core): add mutex for handle concurrents access

### DIFF
--- a/action.go
+++ b/action.go
@@ -27,9 +27,12 @@ func (fsm *Fsm) HandleAction(name string) (string, error) {
 	if exist == false {
 		return fsm.current, ErrUnknowAction
 	}
+	fsm.mutex.Lock()
 	if action.from == fsm.current {
 		action.handler()
+		fsm.mutex.Unlock()
 		return fsm.current, nil
 	}
+	fsm.mutex.Unlock()
 	return fsm.current, ErrBadState
 }

--- a/fsm.go
+++ b/fsm.go
@@ -1,9 +1,13 @@
 // Package fsm is a library tool for finite state nachine
 package fsm
 
+import "sync"
+
 // Fsm is a finitate state machine
 // Fsm define the possible transitions, actions, the states possible and the current state
 type Fsm struct {
+	// mutex for handle goroutines access
+	mutex *sync.Mutex
 	// current state of the fsm
 	current string
 	// states possible for the fsm
@@ -30,9 +34,10 @@ func New(states []string, current string) (*Fsm, error) {
 	if isValideState(states, current) == false {
 		return nil, ErrUnknowState
 	}
+	mutex := &sync.Mutex{}
 	transitions := make(map[string]transition)
 	actions := make(map[string]action)
-	return &Fsm{current, states, transitions, actions}, nil
+	return &Fsm{mutex, current, states, transitions, actions}, nil
 }
 
 // GetState return the current state of the fsm

--- a/transition.go
+++ b/transition.go
@@ -36,10 +36,13 @@ func (fsm *Fsm) HandleTransition(name string) (string, error) {
 	if exist == false {
 		return fsm.current, ErrUnknowTransition
 	}
+	fsm.mutex.Lock()
 	if transition.from == fsm.current {
 		transition.handler()
 		fsm.current = transition.to
+		fsm.mutex.Unlock()
 		return fsm.current, nil
 	}
+	fsm.mutex.Unlock()
 	return fsm.current, ErrBadState
 }


### PR DESCRIPTION
The mutex will allow to lock the state when executing an action or a
transitions, avoiding for example that two differente transitions, with
a common from state and differents end states, access at the same time and then
access concurrently to the current state, overriding each others