### PR TITLE
rf(core): use RWMutex instead of Mutex

### DIFF
--- a/action.go
+++ b/action.go
@@ -15,8 +15,7 @@ func (fsm *Fsm) AddAction(name string, from string, handler func()) error {
 	if isValideState(fsm.states, from) == false {
 		return ErrUnknowState
 	}
-	action := action{from, handler}
-	fsm.actions[name] = action
+	fsm.actions[name] = action{from, handler}
 	return nil
 }
 
@@ -27,12 +26,13 @@ func (fsm *Fsm) HandleAction(name string) (string, error) {
 	if exist == false {
 		return fsm.current, ErrUnknowAction
 	}
-	fsm.mutex.Lock()
+
+	fsm.mutex.RLock()
+	defer fsm.mutex.RUnlock()
+
 	if action.from == fsm.current {
 		action.handler()
-		fsm.mutex.Unlock()
 		return fsm.current, nil
 	}
-	fsm.mutex.Unlock()
 	return fsm.current, ErrBadState
 }

--- a/fsm.go
+++ b/fsm.go
@@ -7,7 +7,7 @@ import "sync"
 // Fsm define the possible transitions, actions, the states possible and the current state
 type Fsm struct {
 	// mutex for handle goroutines access
-	mutex *sync.Mutex
+	mutex *sync.RWMutex
 	// current state of the fsm
 	current string
 	// states possible for the fsm
@@ -34,7 +34,7 @@ func New(states []string, current string) (*Fsm, error) {
 	if isValideState(states, current) == false {
 		return nil, ErrUnknowState
 	}
-	mutex := &sync.Mutex{}
+	mutex := &sync.RWMutex{}
 	transitions := make(map[string]transition)
 	actions := make(map[string]action)
 	return &Fsm{mutex, current, states, transitions, actions}, nil

--- a/transition.go
+++ b/transition.go
@@ -23,8 +23,7 @@ func (fsm *Fsm) AddTransition(name string, from string, to string, handler func(
 		return ErrUnknowState
 	}
 
-	transition := transition{from, to, handler}
-	fsm.transitions[name] = transition
+	fsm.transitions[name] = transition{from, to, handler}
 	return nil
 }
 
@@ -36,13 +35,14 @@ func (fsm *Fsm) HandleTransition(name string) (string, error) {
 	if exist == false {
 		return fsm.current, ErrUnknowTransition
 	}
+
 	fsm.mutex.Lock()
+	defer fsm.mutex.Unlock()
+
 	if transition.from == fsm.current {
 		transition.handler()
 		fsm.current = transition.to
-		fsm.mutex.Unlock()
 		return fsm.current, nil
 	}
-	fsm.mutex.Unlock()
 	return fsm.current, ErrBadState
 }


### PR DESCRIPTION
Because action doens't reassign the state it just need a read lock